### PR TITLE
feat: make it available for ssr

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -220,6 +220,8 @@ export const murmurhash3_32_gc = (key) => {
   return h1 >>> 0;
 };
 
-window.getBrowserFingerprint = getBrowserFingerprint;
+if (typeof window !== 'undefined') {
+  window.getBrowserFingerprint = getBrowserFingerprint;
+}
 
 export default getBrowserFingerprint;


### PR DESCRIPTION
This package may be used in a framework that supports server-side rendering. In this case, making the function available for `window` is inappropriate, because it may be undefined.

Without producing breaking changes, I added a condition that `window` needs to be defined.

EDIT: I guess you assigned the function to `window` to be able to test it. If it's ok, I can refactor the test so it wouldn't need it.