### PR TITLE
Improve readability and performance of browser fingerprinting

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -74,24 +74,26 @@ const isMobile = () =>
 
 /** @type {import('./index.d.ts').getBrowserFingerprint} */
 const getBrowserFingerprint = async ({ debug = false } = {}) => {
-  // software
-  const fonts = await safe(() => getFonts());
-  const numberingSystem = await safe(() => new Intl.NumberFormat(window.navigator.languages?.[0] || 'en').resolvedOptions().numberingSystem);
+  // synchronous signals
   const languages = window.navigator.languages ? Array.from(window.navigator.languages).join(',') : window.navigator.language || null;
   const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
   const timezoneOffset = new Date().getTimezoneOffset();
   const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches ? 'reduce' : 'no-preference';
   const colorScheme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-
-  // hardware
   const forcedColors = window.matchMedia('(forced-colors: active)').matches ? 'active' : null;
   const { pixelDepth, colorDepth } = window.screen;
   const touchSupport = 'ontouchstart' in window || window.navigator.maxTouchPoints > 0;
-  const canvasID = await safe(() => getCanvasID(debug));
-  const webglID = await safe(() => getWebglID());
-  const webgpuID = await safe(() => getWebgpuID(debug));
-  const audioID = await safe(() => getAudioID(debug));
   const aspectRatio = window.screen.width && window.screen.height ? (window.screen.width / window.screen.height).toFixed(4) : null;
+
+  // async signals collected in parallel
+  const [fonts, numberingSystem, canvasID, webglID, webgpuID, audioID] = await Promise.all([
+    safe(getFonts),
+    safe(() => new Intl.NumberFormat(window.navigator.languages?.[0] || 'en').resolvedOptions().numberingSystem),
+    safe(() => getCanvasID(debug)),
+    safe(getWebglID),
+    safe(() => getWebgpuID(debug)),
+    safe(() => getAudioID(debug)),
+  ]);
 
   const data = {
     // SOFTWARE
@@ -187,6 +189,7 @@ const getCanvasID = async (debug) => {
 const getWebglID = () => {
   const canvas = document.createElement('canvas');
   const gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl');
+  if (!gl) return null;
   const debugInfo = gl.getExtension('WEBGL_debug_renderer_info');
   const vendor = debugInfo ? gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL) : gl.getParameter(gl.VENDOR);
   const renderer = debugInfo ? gl.getParameter(debugInfo.UNMASKED_RENDERER_WEBGL) : gl.getParameter(gl.RENDERER);

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -24,15 +24,25 @@ describe('getBrowserFingerprint', () => {
     assert.ok(result.fingerprint.length === 8);
   });
 
-  it('works with hardwareOnly=true', async () => {
-    const result = await evaluateFn(page, { hardwareOnly: true });
+  it('returns a deterministic fingerprint', async () => {
+    const result1 = await evaluateFn(page, {});
+    const result2 = await evaluateFn(page, {});
+    assert.equal(result1.fingerprint, result2.fingerprint);
+  });
+
+  it('works with debug=true', async () => {
+    const result = await evaluateFn(page, { debug: true });
     assert.equal(typeof result.fingerprint, 'string');
     assert.ok(result.fingerprint.length === 8);
   });
 
-  it('works with enableWebgl=true', async () => {
-    const result = await evaluateFn(page, { enableWebgl: true });
-    assert.equal(typeof result.fingerprint, 'string');
-    assert.ok(result.fingerprint.length === 8);
+  it('includes expected data fields', async () => {
+    const result = await evaluateFn(page, {});
+    assert.ok('timezone' in result);
+    assert.ok('languages' in result);
+    assert.ok('colorScheme' in result);
+    assert.ok('touchSupport' in result);
+    assert.ok('pixelDepth' in result);
+    assert.ok('colorDepth' in result);
   });
 });


### PR DESCRIPTION
- [x] Parallelize independent async data collection in `getBrowserFingerprint` using `Promise.all` (performance: canvas, webgl, webgpu, audio, fonts run concurrently instead of sequentially)
- [x] Add null guard for WebGL context in `getWebglID` (prevents potential null dereference when WebGL is unavailable)
- [x] Group synchronous vs async signal collection with clear comments (readability)
- [x] Fix tests that referenced non-existent options (`hardwareOnly`, `enableWebgl`), add meaningful tests (deterministic check, debug mode, expected data fields)