### PR TITLE
Replace MurmurHash3 with SHA-256 and extend fingerprint signals	

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,60 +1,131 @@
 # get-browser-fingerprint
 
-A single and fast (<50ms) asynchronous function returning a browser fingerprint, without requiring any permission to the user.  
-Live [example here](https://damianobarbati.github.io/get-browser-fingerprint/).  
+A single asynchronous function that returns a browser fingerprint (64‑char hex, SHA‑256) without requiring any user permission.
+
+Live [example here](https://damianobarbati.github.io/get-browser-fingerprint/).
+
+## Return value
+
+- **`fingerprint`** — SHA‑256 hash (hex) of the stable stringified payload.
+- **`elapsedMs`** — Execution time in milliseconds.
+- All collected signals are also spread on the returned object (e.g. `timezone`, `canvasID`, `webglID`, `languages`, …).
+
+## Collected signals
+
+- **UA / platform:** `vendor`, `platform`, `userAgentHighEntropy` (UA Client Hints: architecture, bitness, platformVersion, model, fullVersionList).
+- **Locale / Intl:** `languages`, `timezone`, `timezoneOffset`, `numberingSystem`, `intlCalendar`, `hourCycle`, `intlSupportedCalendars`.
+- **Preferences:** `reducedMotion`, `colorScheme`, `prefersContrast`, `prefersReducedTransparency`, `forcedColors`.
+- **Screen:** `devicePixelRatio`, `pixelDepth`, `colorDepth`, `screenOrientation`; on mobile: `width`, `height`, `aspectRatio`, `maxTouchPoints`.
+- **Network:** `connectionType`, `effectiveType`, `saveData` (when available).
+- **Device:** `hardwareConcurrency`, `deviceMemory`, `touchSupport`.
+- **Media / codecs:** `mediaCodecs` (canPlayType for common MIME types), `canvasID`, `webglID`, `webgpuID`, `audioID`.
+- **Other:** `fonts` (detected list), `pdfViewerEnabled`, `webdriver`, `permissionsState` (geolocation, notifications).
+
+Signals that fail or are unavailable are set to `null` (no throw).
 
 ## Assumptions
 
-The function is targeting stock installations of the following browsers (no extensions or add-ons installed):
+The function targets stock installations of:
+
 - Google Chrome (desktop and Android)
-- Mozilla Firefox (desktop, default tracking protection, no custom privacy flags enabled)
+- Mozilla Firefox (desktop, default tracking protection)
 - Microsoft Edge (desktop and Android)
 - Apple Safari (macOS)
 - Safari on iOS / iPadOS
 
-Explicit assumptions:
-- No privacy-focused extensions or add-ons installed.
-- Browser privacy settings left at factory defaults (no manual changes to fingerprint resistance features).
-- No hardened, anti-detect or heavily modified browser variants.
+Assumptions:
 
-Under these conditions the collected signals retain meaningful entropy in February 2026:
-- Canvas rendering (stable on Chrome, Edge, Firefox default; noisy or low-entropy on iOS Safari and partially on macOS Safari)
-- WebGL unmasked vendor and renderer (strong on desktop, more uniform on mobile)
-- Offline audio context (useful on Chrome, Edge, Firefox; heavily restricted on Safari)
-- WebGPU properties (if available; low but increasing entropy)
-- Locally installed fonts (valuable mainly on desktop Windows and macOS)
-- Passive signals (hardwareConcurrency, deviceMemory, screen, timezone, languages, etc.)
+- No privacy-focused extensions or add-ons.
+- Browser privacy settings at factory defaults.
+- No hardened or anti-detect browser variants.
 
-On browsers with strong default fingerprint resistance (Safari iOS, certain Firefox modes) entropy and stability decrease significantly.  
-The script does not attempt to bypass intentional randomization or hardening.
+Under these conditions the signals keep useful entropy; on Safari iOS or strict Firefox modes entropy can be lower. The script does not try to bypass intentional randomization or hardening.
 
 ## Usage
 
-Get browser fingerprint:
 ```js
-import getBrowserFingerprint from 'get-browser-fingerprint';
-const { fingerprint } = await getBrowserFingerprint();
-console.log(fingerprint);
+// Import the default async function
+import getBrowserFingerprint from 'get-browser-fingerprint'
+
+// Call once; result holds fingerprint, elapsedMs, and all collected signals
+const result = await getBrowserFingerprint()
+// Log the 64-char hex fingerprint
+console.log(result.fingerprint)
+// Log execution time in milliseconds
+console.log(result.elapsedMs)
+
+// Or destructure to get only the fingerprint
+const { fingerprint } = await getBrowserFingerprint()
+console.log(fingerprint)
 ```
 
-Options available:
-- `debug` (default `false`): log data used to generate fingerprint to console and add canvas/webgl/audio elements to body.
+Options:
+
+- **`debug`** (default `false`): append canvas / WebGL / audio debug elements to `document.body` and include extra debug output.
+
+```js
+const result = await getBrowserFingerprint({ debug: true })
+```
+
+### CDN
+
+Load as ESM from a CDN (secure context required):
+
+```html
+<script type="module">
+  import getBrowserFingerprint from 'https://cdn.jsdelivr.net/npm/get-browser-fingerprint/+esm'
+  const { fingerprint, elapsedMs } = await getBrowserFingerprint()
+  console.log(fingerprint, elapsedMs)
+</script>
+```
+
+Or with a version pin:
+
+```html
+<script type="module">
+  import getBrowserFingerprint from 'https://cdn.jsdelivr.net/npm/get-browser-fingerprint@latest/+esm'
+  const result = await getBrowserFingerprint()
+  console.log(result.fingerprint)
+</script>
+```
 
 ## Development
 
-To test locally:
+Install and run tests:
+
 ```sh
-fnm install # nodejs from .nvmrc
+fnm install
 npm install -g corepack
-corepack enable # package manager from package.json
-corepack install # package manager from package.json
-pnpm install # install deps
+corepack enable
+corepack install
+pnpm install
 pnpm exec playwright install chromium
 pnpm exec playwright install firefox
 pnpm test
 ```
 
-To run the example locally:
+Run the demo locally (serve `src/`):
+
 ```sh
 pnpm serve -p 80 ./src
+# or
+npm run serve
 ```
+
+Then open `http://localhost/index.html` (or port 80 if using `-p 80`).
+
+## References
+
+- [Fingerprinting (MDN Glossary)](https://developer.mozilla.org/en-US/docs/Glossary/Fingerprinting)
+- [HTTP Client hints (MDN)](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Client_hints)
+- [Intl.DateTimeFormat.resolvedOptions() (MDN)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/resolvedOptions)
+- [Intl.supportedValuesOf() (MDN)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/supportedValuesOf)
+- [Mitigating Browser Fingerprinting (W3C)](https://w3c.github.io/fingerprinting-guidance/)
+- [Navigator (MDN)](https://developer.mozilla.org/en-US/docs/Web/API/Navigator)
+- [NavigatorUAData.getHighEntropyValues() (MDN)](https://developer.mozilla.org/en-US/docs/Web/API/NavigatorUAData/getHighEntropyValues)
+- [NetworkInformation (MDN)](https://developer.mozilla.org/en-US/docs/Web/API/NetworkInformation)
+- [Permissions API (MDN)](https://developer.mozilla.org/en-US/docs/Web/API/Permissions_API)
+- [Screen (MDN)](https://developer.mozilla.org/en-US/docs/Web/API/Screen)
+- [SubtleCrypto.digest() (MDN)](https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/digest)
+- [User-Agent Client Hints API (MDN)](https://developer.mozilla.org/en-US/docs/Web/API/User-Agent_Client_Hints_API)
+- [Window.devicePixelRatio (MDN)](https://developer.mozilla.org/en-US/docs/Web/API/Window/devicePixelRatio)

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # get-browser-fingerprint
 
-A single asynchronous function that returns a browser fingerprint (64‑char hex, SHA‑256) without requiring any user permission.
+A single asynchronous function that returns a browser fingerprint (8‑char hex) without requiring any user permission.
 
 Live [example here](https://damianobarbati.github.io/get-browser-fingerprint/).
 
 ## Return value
 
-- **`fingerprint`** — SHA‑256 hash (hex) of the stable stringified payload.
+- **`fingerprint`** — MurmurHash3 (32-bit, hex) of the stable stringified payload.
 - **`elapsedMs`** — Execution time in milliseconds.
 - All collected signals are also spread on the returned object (e.g. `timezone`, `canvasID`, `webglID`, `languages`, …).
 
@@ -49,7 +49,7 @@ import getBrowserFingerprint from 'get-browser-fingerprint'
 
 // Call once; result holds fingerprint, elapsedMs, and all collected signals
 const result = await getBrowserFingerprint()
-// Log the 64-char hex fingerprint
+// Log the 8-char hex fingerprint
 console.log(result.fingerprint)
 // Log execution time in milliseconds
 console.log(result.elapsedMs)
@@ -69,7 +69,7 @@ const result = await getBrowserFingerprint({ debug: true })
 
 ### CDN
 
-Load as ESM from a CDN (secure context required):
+Load as ESM from a CDN:
 
 ```html
 <script type="module">
@@ -126,6 +126,5 @@ Then open `http://localhost/index.html` (or port 80 if using `-p 80`).
 - [NetworkInformation (MDN)](https://developer.mozilla.org/en-US/docs/Web/API/NetworkInformation)
 - [Permissions API (MDN)](https://developer.mozilla.org/en-US/docs/Web/API/Permissions_API)
 - [Screen (MDN)](https://developer.mozilla.org/en-US/docs/Web/API/Screen)
-- [SubtleCrypto.digest() (MDN)](https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/digest)
 - [User-Agent Client Hints API (MDN)](https://developer.mozilla.org/en-US/docs/Web/API/User-Agent_Client_Hints_API)
 - [Window.devicePixelRatio (MDN)](https://developer.mozilla.org/en-US/docs/Web/API/Window/devicePixelRatio)

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -4,7 +4,8 @@ export interface FingerprintOptions {
 
 export type FingerprintResult = {
   fingerprint: string;
-} & Record<string, string>;
+  elapsedMs: number;
+} & Record<string, unknown>;
 
 export default function getBrowserFingerprint(options?: FingerprintOptions): Promise<FingerprintResult>;
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,301 +1,108 @@
-const murmurHash3 = (key, seed = 0) => {
-  let h = seed ^ key.length;
-
-  let i = 0;
-  const len = key.length;
-
-  while (i + 3 < len) {
-    let k = (key.charCodeAt(i) & 0xff) | ((key.charCodeAt(i + 1) & 0xff) << 8) | ((key.charCodeAt(i + 2) & 0xff) << 16) | ((key.charCodeAt(i + 3) & 0xff) << 24);
-    k = Math.imul(k, 0xcc9e2d51);
-    k = (k << 15) | (k >>> 17); // ROTL32(k, 15)
-    k = Math.imul(k, 0x1b873593);
-    h ^= k;
-    h = (h << 13) | (h >>> 19); // ROTL32(h, 13)
-    h = Math.imul(h, 5) + 0xe6546b64;
-    i += 4;
-  }
-
-  // tail
-  let k1 = 0;
-  switch (len - i) {
-    // biome-ignore lint/suspicious/noFallthroughSwitchClause: ignore
-    case 3:
-      k1 ^= (key.charCodeAt(i + 2) & 0xff) << 16;
-    // biome-ignore lint/suspicious/noFallthroughSwitchClause: ignore
-    case 2:
-      k1 ^= (key.charCodeAt(i + 1) & 0xff) << 8;
-    case 1:
-      k1 ^= key.charCodeAt(i) & 0xff;
-      k1 = Math.imul(k1, 0xcc9e2d51);
-      k1 = (k1 << 15) | (k1 >>> 17);
-      k1 = Math.imul(k1, 0x1b873593);
-      h ^= k1;
-  }
-
-  h ^= h >>> 16;
-  h = Math.imul(h, 0x85ebca6b);
-  h ^= h >>> 13;
-  h = Math.imul(h, 0xc2b2ae35);
-  h ^= h >>> 16;
-  h = h >>> 0; // force unsigned 32 bit
-
-  const result = h.toString(16).padStart(8, '0');
-  return result;
-};
-
-const safe = async (fn) => {
-  try {
-    return await fn();
-  } catch {
-    return null;
-  }
-};
-
-const stableStringify = (obj) => {
-  // handle null, string, number, boolean
-  if (obj === null || typeof obj !== 'object') return JSON.stringify(obj);
-  // handle arrays recursively
-  if (Array.isArray(obj)) return `[${obj.map(stableStringify).join(',')}]`;
-
-  const keys = Object.keys(obj).sort();
-  const parts = [];
-  for (const key of keys) {
-    const value = obj[key];
-    if (value !== undefined) parts.push(`${stableStringify(key)}:${stableStringify(value)}`);
-  }
-
-  return `{${parts.join(',')}}`;
-};
-
-const isMobile = () =>
-  navigator.userAgentData?.mobile === true ||
-  /Mobi|Android|iPhone|iPad|iPod|webOS|BlackBerry|Windows Phone/i.test(navigator.userAgent) ||
-  (navigator.maxTouchPoints > 0 && matchMedia('(pointer:coarse)').matches && innerWidth <= 1024);
-
-/** @type {import('./index.d.ts').getBrowserFingerprint} */
-const getBrowserFingerprint = async ({ debug = false } = {}) => {
-  // software
-  const fonts = await safe(() => getFonts());
-  const numberingSystem = await safe(() => new Intl.NumberFormat(window.navigator.languages?.[0] || 'en').resolvedOptions().numberingSystem);
-  const languages = window.navigator.languages ? Array.from(window.navigator.languages).join(',') : window.navigator.language || null;
-  const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-  const timezoneOffset = new Date().getTimezoneOffset();
-  const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches ? 'reduce' : 'no-preference';
-  const colorScheme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
-
-  // hardware
-  const forcedColors = window.matchMedia('(forced-colors: active)').matches ? 'active' : null;
-  const { pixelDepth, colorDepth } = window.screen;
-  const touchSupport = 'ontouchstart' in window || window.navigator.maxTouchPoints > 0;
-  const canvasID = await safe(() => getCanvasID(debug));
-  const webglID = await safe(() => getWebglID());
-  const webgpuID = await safe(() => getWebgpuID(debug));
-  const audioID = await safe(() => getAudioID(debug));
-  const aspectRatio = window.screen.width && window.screen.height ? (window.screen.width / window.screen.height).toFixed(4) : null;
-
-  const data = {
-    // SOFTWARE
-    vendor: window.navigator.vendor || null, // vendor
-    platform: window.navigator.platform || null, // os
-    fonts, // stable default os setting
-    numberingSystem, // stable default os setting
-    languages, // stable user locale/setting
-    timezone, // stable user locale/setting
-    timezoneOffset, // stable user locale/setting
-    reducedMotion, // stable user locale/setting
-    colorScheme, // stable user locale/setting
-    // HARDWARE
-    hardwareConcurrency: window.navigator.hardwareConcurrency || null, // cpu
-    deviceMemory: window.navigator.deviceMemory || null, // ram
-    forcedColors, // display
-    pixelDepth, // display
-    colorDepth, // display
-    touchSupport, // display
-    canvasID, // gpu
-    webglID, // gpu
-    webgpuID, // gpu
-    audioID, // audio
-  };
-
-  const mobileData = {
-    aspectRatio,
-    width: window.screen.width,
-    height: window.screen.height,
-    maxTouchPoints: window.navigator.maxTouchPoints,
-  };
-
-  if (isMobile()) Object.assign(data, mobileData);
-
-  const payload = stableStringify(data);
-  const fingerprint = murmurHash3(payload);
-  return { fingerprint, ...data };
-};
-
-const getCanvasID = async (debug) => {
-  const canvas = document.createElement('canvas');
-  canvas.width = 280;
-  canvas.height = 100;
-  const ctx = canvas.getContext('2d');
-
-  // background with gradient
-  const grad = ctx.createLinearGradient(0, 0, 280, 100);
-  grad.addColorStop(0, '#f60');
-  grad.addColorStop(0.4, '#09f');
-  grad.addColorStop(0.7, '#f09');
-  grad.addColorStop(1, '#0f9');
-  ctx.fillStyle = grad;
-  ctx.fillRect(0, 0, 280, 100);
-
-  // text with multiple fonts and emoji
-  ctx.font = '18px "Arial","Helvetica","DejaVu Sans",sans-serif';
-  ctx.fillStyle = '#000';
-  ctx.textBaseline = 'alphabetic';
-  ctx.fillText('Fingerprint ¼½¾™©®∆π∑€¶§', 12, 45);
-
-  ctx.font = 'bold 22px "Georgia","Times New Roman",serif';
-  ctx.fillStyle = '#222';
-  ctx.fillText('🦊🐱🚀 2026', 12, 78);
-
-  // content with antialiasing and compositing
-  ctx.globalAlpha = 0.7;
-  ctx.fillStyle = 'rgba(255, 80, 0, 0.35)';
-  ctx.fillRect(180, 20, 80, 60);
-
-  ctx.beginPath();
-  ctx.arc(220, 50, 32, 0, Math.PI * 2);
-  ctx.strokeStyle = '#fff';
-  ctx.lineWidth = 4;
-  ctx.stroke();
-
-  ctx.beginPath();
-  ctx.moveTo(30, 85);
-  ctx.quadraticCurveTo(140, 20, 240, 85);
-  ctx.strokeStyle = '#00f';
-  ctx.lineWidth = 3;
-  ctx.stroke();
-
-  if (debug) {
-    canvas.style.border = '1px solid #444';
-    document.body.appendChild(canvas);
-  }
-
-  const dataUrl = canvas.toDataURL('image/png');
-  const result = murmurHash3(dataUrl);
-  return result;
-};
-
-const getWebglID = () => {
-  const canvas = document.createElement('canvas');
-  const gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl');
-  const debugInfo = gl.getExtension('WEBGL_debug_renderer_info');
-  const vendor = debugInfo ? gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL) : gl.getParameter(gl.VENDOR);
-  const renderer = debugInfo ? gl.getParameter(debugInfo.UNMASKED_RENDERER_WEBGL) : gl.getParameter(gl.RENDERER);
-  const info = { vendor, renderer };
-  const result = murmurHash3(stableStringify(info));
-  return result;
-};
-
-const getWebgpuID = async (debug) => {
-  const adapter = await navigator.gpu.requestAdapter({ powerPreference: 'high-performance' });
-  const vendor = adapter.info?.vendor ?? '';
-  const architecture = adapter.info?.architecture ?? '';
-  const description = adapter.info?.description ?? '';
-  const features = Array.from(adapter.features).sort();
-  const limits = Array.from(adapter.limits).sort();
-  const info = { vendor, architecture, description, features, limits };
-
-  if (debug) {
-    const debugDiv = document.createElement('pre');
-    debugDiv.style.margin = '10px 0';
-    debugDiv.style.padding = '10px';
-    debugDiv.style.border = '1px solid #444';
-    debugDiv.style.background = '#111';
-    debugDiv.style.color = '#0f8';
-    debugDiv.style.fontFamily = 'monospace';
-    debugDiv.textContent = `WebGPU:\n${JSON.stringify(info, null, 2)}`;
-    document.body.appendChild(debugDiv);
-  }
-
-  const result = murmurHash3(stableStringify(info));
-  return result;
-};
-
-const getAudioID = async (debug) => {
-  const OfflineCtx = window.OfflineAudioContext || window.webkitOfflineAudioContext;
-
-  const context = new OfflineCtx(1, 6000, 44100);
-  const osc = context.createOscillator();
-  osc.type = 'sawtooth';
-  osc.frequency.value = 8800;
-
-  const compressor = context.createDynamicsCompressor();
-  compressor.threshold.value = -48;
-  compressor.knee.value = 30;
-  compressor.ratio.value = 14;
-  compressor.attack.value = 0;
-  compressor.release.value = 0.3;
-
-  const gain = context.createGain();
-  gain.gain.value = 0.4;
-
-  osc.connect(compressor);
-  compressor.connect(gain);
-  gain.connect(context.destination);
-
-  osc.start(0);
-  const buffer = await context.startRendering();
-  const channel = buffer.getChannelData(0);
-
-  let hash = 0;
-  let hash2 = 0;
+const getAudioID = async isDebug => {
+  const OfflineCtx = window.OfflineAudioContext || window.webkitOfflineAudioContext
+  const context = new OfflineCtx(1, 6000, 44100)
+  const osc = context.createOscillator()
+  osc.type = 'sawtooth'
+  osc.frequency.value = 8800
+  const compressor = context.createDynamicsCompressor()
+  compressor.threshold.value = -48
+  compressor.knee.value = 30
+  compressor.ratio.value = 14
+  compressor.attack.value = 0
+  compressor.release.value = 0.3
+  const gain = context.createGain()
+  gain.gain.value = 0.4
+  osc.connect(compressor)
+  compressor.connect(gain)
+  gain.connect(context.destination)
+  osc.start(0)
+  const buffer = await context.startRendering()
+  const channel = buffer.getChannelData(0)
+  let hash = 0
+  let hash2 = 0
   for (let i = 3000; i < 5800; i += 2) {
-    const v = channel[i];
-    hash = (hash * 31 + Math.floor((v + 1) * 100000)) | 0;
-    hash2 = Math.imul(hash2 ^ Math.floor(v * 98765), 0x85ebca77);
+    const sampleValue = channel[i]
+    hash = (hash * 31 + Math.floor((sampleValue + 1) * 100000)) | 0
+    hash2 = Math.imul(hash2 ^ Math.floor(sampleValue * 98765), 0x85ebca77)
   }
-  const final = (hash >>> 0) ^ (hash2 >>> 0);
-
-  if (debug) {
-    const wc = document.createElement('canvas');
-    wc.width = 500;
-    wc.height = 120;
-    wc.style.border = '1px solid #444';
-    wc.style.margin = '10px 0';
-    wc.title = 'Audio buffer snippet (4500–5000 samples)';
-
-    const ctx = wc.getContext('2d');
-    ctx.fillStyle = '#111';
-    ctx.fillRect(0, 0, wc.width, wc.height);
-
-    ctx.font = '14px monospace';
-    ctx.fillStyle = '#0f8';
-    ctx.textAlign = 'left';
-    ctx.fillText('AudioID', 10, 20);
-
-    ctx.strokeStyle = '#0f8';
-    ctx.lineWidth = 1.5;
-    ctx.beginPath();
-
-    const waveform = Array.from(channel.slice(4500, 5000));
-    const step = wc.width / waveform.length;
-
+  const final = (hash >>> 0) ^ (hash2 >>> 0)
+  if (isDebug) {
+    const waveformCanvas = document.createElement('canvas')
+    waveformCanvas.width = 500
+    waveformCanvas.height = 120
+    waveformCanvas.style.border = '1px solid #444'
+    waveformCanvas.style.margin = '10px 0'
+    waveformCanvas.title = 'Audio buffer snippet (4500–5000 samples)'
+    const ctx = waveformCanvas.getContext('2d')
+    ctx.fillStyle = '#111'
+    ctx.fillRect(0, 0, waveformCanvas.width, waveformCanvas.height)
+    ctx.font = '14px monospace'
+    ctx.fillStyle = '#0f8'
+    ctx.textAlign = 'left'
+    ctx.fillText('AudioID', 10, 20)
+    ctx.strokeStyle = '#0f8'
+    ctx.lineWidth = 1.5
+    ctx.beginPath()
+    const waveform = Array.from(channel.slice(4500, 5000))
+    const step = waveformCanvas.width / waveform.length
     for (let i = 0; i < waveform.length; i++) {
-      const x = i * step;
-      const y = ((waveform[i] + 1) / 2) * wc.height;
-      if (i === 0) ctx.moveTo(x, y);
-      else ctx.lineTo(x, y);
+      const x = i * step
+      const y = ((waveform[i] + 1) / 2) * waveformCanvas.height
+      if (i === 0) {
+        ctx.moveTo(x, y)
+      } else {
+        ctx.lineTo(x, y)
+      }
     }
-    ctx.stroke();
-
-    document.body.appendChild(wc);
+    ctx.stroke()
+    document.body.appendChild(waveformCanvas)
   }
+  return await sha256Hex(final.toString(16))
+}
 
-  const result = murmurHash3(final.toString(16));
-  return result;
-};
+const getCanvasID = async isDebug => {
+  const canvas = document.createElement('canvas')
+  canvas.width = 280
+  canvas.height = 100
+  const ctx = canvas.getContext('2d')
+  const gradient = ctx.createLinearGradient(0, 0, 280, 100)
+  gradient.addColorStop(0, '#f60')
+  gradient.addColorStop(0.4, '#09f')
+  gradient.addColorStop(0.7, '#f09')
+  gradient.addColorStop(1, '#0f9')
+  ctx.fillStyle = gradient
+  ctx.fillRect(0, 0, 280, 100)
+  ctx.font = '18px "Arial","Helvetica","DejaVu Sans",sans-serif'
+  ctx.fillStyle = '#000'
+  ctx.textBaseline = 'alphabetic'
+  ctx.fillText('Fingerprint ¼½¾™©®∆π∑€¶§', 12, 45)
+  ctx.font = 'bold 22px "Georgia","Times New Roman",serif'
+  ctx.fillStyle = '#222'
+  ctx.fillText('🦊🐱🚀 2026', 12, 78)
+  ctx.globalAlpha = 0.7
+  ctx.fillStyle = 'rgba(255, 80, 0, 0.35)'
+  ctx.fillRect(180, 20, 80, 60)
+  ctx.beginPath()
+  ctx.arc(220, 50, 32, 0, Math.PI * 2)
+  ctx.strokeStyle = '#fff'
+  ctx.lineWidth = 4
+  ctx.stroke()
+  ctx.beginPath()
+  ctx.moveTo(30, 85)
+  ctx.quadraticCurveTo(140, 20, 240, 85)
+  ctx.strokeStyle = '#00f'
+  ctx.lineWidth = 3
+  ctx.stroke()
+  if (isDebug) {
+    canvas.style.border = '1px solid #444'
+    document.body.appendChild(canvas)
+  }
+  const dataUrl = canvas.toDataURL('image/png')
+  return await sha256Hex(dataUrl)
+}
 
 const getFonts = () => {
-  const baseFonts = ['monospace', 'serif', 'sans-serif'];
+  const baseFonts = ['monospace', 'serif', 'sans-serif']
   const testFonts = [
     'Arial',
     'Helvetica',
@@ -311,49 +118,291 @@ const getFonts = () => {
     'Noto Sans',
     'system-ui',
     '-apple-system',
-    'BlinkMacSystemFont',
-  ];
-
-  const span = document.createElement('span');
-  span.style.fontSize = '72px';
-  span.style.position = 'absolute';
-  span.style.visibility = 'hidden';
-  span.style.whiteSpace = 'nowrap';
-  span.textContent = 'mmmmmmmmmwwwwwww';
-  document.body.appendChild(span);
-
-  const defaults = {};
+    'BlinkMacSystemFont'
+  ]
+  const span = document.createElement('span')
+  span.style.fontSize = '72px'
+  span.style.position = 'absolute'
+  span.style.visibility = 'hidden'
+  span.style.whiteSpace = 'nowrap'
+  span.textContent = 'mmmmmmmmmwwwwwww'
+  document.body.appendChild(span)
+  const defaults = {}
   for (const base of baseFonts) {
-    span.style.fontFamily = base;
-    defaults[base] = span.offsetWidth;
+    span.style.fontFamily = base
+    defaults[base] = span.offsetWidth
   }
-
-  const detected = [];
+  const detected = []
   for (const font of testFonts) {
-    let found = false;
+    let found = false
     for (const base of baseFonts) {
-      span.style.fontFamily = `"${font}", ${base}`;
+      span.style.fontFamily = `"${font}", ${base}`
       if (span.offsetWidth !== defaults[base]) {
-        detected.push(font);
-        found = true;
-        break;
+        detected.push(font)
+        found = true
+        break
       }
     }
     if (!found) {
-      span.style.fontFamily = `"${font}"`;
+      span.style.fontFamily = `"${font}"`
       if (span.offsetWidth !== defaults.monospace && span.offsetWidth !== defaults.serif) {
-        detected.push(font);
+        detected.push(font)
       }
     }
   }
-
-  document.body.removeChild(span);
-  const info = detected.length ? detected.sort().join(',') : null;
-  return info;
-};
-
-if (typeof window !== 'undefined') {
-  window.getBrowserFingerprint = getBrowserFingerprint;
+  document.body.removeChild(span)
+  return detected.length ? detected.sort().join(',') : null
 }
 
-export default getBrowserFingerprint;
+const getMediaCodecs = () => {
+  const video = document.createElement('video')
+  const mimeList = [
+    'video/webm',
+    'video/mp4',
+    'video/ogg',
+    'audio/mp4',
+    'audio/webm',
+    'audio/ogg',
+    'audio/mpeg'
+  ]
+  const codecSupportMap = {}
+  for (const mime of mimeList) {
+    const playbackSupport = video.canPlayType(mime)
+    codecSupportMap[mime] = playbackSupport === '' ? 'no' : playbackSupport
+  }
+  return stableStringify(codecSupportMap)
+}
+
+const getWebglID = async () => {
+  const canvas = document.createElement('canvas')
+  const gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl')
+  const debugInfo = gl.getExtension('WEBGL_debug_renderer_info')
+  const vendor = debugInfo
+    ? gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL)
+    : gl.getParameter(gl.VENDOR)
+  const renderer = debugInfo
+    ? gl.getParameter(debugInfo.UNMASKED_RENDERER_WEBGL)
+    : gl.getParameter(gl.RENDERER)
+  const webglInfo = { vendor, renderer }
+  return await sha256Hex(stableStringify(webglInfo))
+}
+
+const getWebgpuID = async isDebug => {
+  const adapter = await navigator.gpu.requestAdapter({ powerPreference: 'high-performance' })
+  const vendor = adapter.info?.vendor ?? ''
+  const architecture = adapter.info?.architecture ?? ''
+  const description = adapter.info?.description ?? ''
+  const features = Array.from(adapter.features).sort()
+  const limits = Array.from(adapter.limits).sort()
+  const webgpuInfo = { vendor, architecture, description, features, limits }
+  if (isDebug) {
+    const debugDiv = document.createElement('pre')
+    debugDiv.style.margin = '10px 0'
+    debugDiv.style.padding = '10px'
+    debugDiv.style.border = '1px solid #444'
+    debugDiv.style.background = '#111'
+    debugDiv.style.color = '#0f8'
+    debugDiv.style.fontFamily = 'monospace'
+    debugDiv.textContent = `WebGPU:\n${JSON.stringify(webgpuInfo, null, 2)}`
+    document.body.appendChild(debugDiv)
+  }
+  return await sha256Hex(stableStringify(webgpuInfo))
+}
+
+const isMobile = () =>
+  navigator.userAgentData?.mobile === true ||
+  /Mobi|Android|iPhone|iPad|iPod|webOS|BlackBerry|Windows Phone/i.test(navigator.userAgent) ||
+  (navigator.maxTouchPoints > 0 && matchMedia('(pointer:coarse)').matches && innerWidth <= 1024)
+
+const safe = async asyncFn => {
+  try {
+    return await asyncFn()
+  } catch {
+    return null
+  }
+}
+
+const sha256Hex = async inputString => {
+  const hashBuffer = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(inputString))
+  return Array.from(new Uint8Array(hashBuffer))
+    .map(byte => byte.toString(16).padStart(2, '0'))
+    .join('')
+}
+
+const stableStringify = value => {
+  if (value === null || typeof value !== 'object') {
+    return JSON.stringify(value)
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(',')}]`
+  }
+  const keys = Object.keys(value).sort()
+  const parts = []
+  for (const key of keys) {
+    const item = value[key]
+    if (item !== undefined) {
+      parts.push(`${stableStringify(key)}:${stableStringify(item)}`)
+    }
+  }
+  return `{${parts.join(',')}}`
+}
+
+const getBrowserFingerprint = async ({ debug: isDebug = false } = {}) => {
+  const startTime = performance.now()
+  const userAgentHighEntropy = await safe(async () => {
+    if (
+      !window.navigator.userAgentData ||
+      typeof window.navigator.userAgentData.getHighEntropyValues !== 'function'
+    ) {
+      return null
+    }
+    const highEntropyValues = await window.navigator.userAgentData.getHighEntropyValues([
+      'architecture',
+      'bitness',
+      'platformVersion',
+      'model',
+      'fullVersionList'
+    ])
+    return stableStringify(highEntropyValues)
+  })
+  const mediaCodecs = await safe(() => getMediaCodecs())
+  const fonts = await safe(() => getFonts())
+  const numberingSystem = await safe(
+    () =>
+      new Intl.NumberFormat(window.navigator.languages?.[0] || 'en').resolvedOptions()
+        .numberingSystem
+  )
+  const languages = window.navigator.languages
+    ? Array.from(window.navigator.languages).join(',')
+    : window.navigator.language || null
+  const intlResolved = Intl.DateTimeFormat().resolvedOptions()
+  const timezone = intlResolved.timeZone
+  const timezoneOffset = new Date().getTimezoneOffset()
+  const intlCalendar = intlResolved.calendar || null
+  const hourCycle =
+    intlResolved.hour12 !== undefined
+      ? intlResolved.hour12
+        ? 'h12'
+        : 'h23'
+      : intlResolved.hourCycle || null
+  const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    ? 'reduce'
+    : 'no-preference'
+  const colorScheme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+  const prefersContrast = window.matchMedia('(prefers-contrast: more)').matches
+    ? 'more'
+    : window.matchMedia('(prefers-contrast: less)').matches
+      ? 'less'
+      : window.matchMedia('(prefers-contrast: custom)').matches
+        ? 'custom'
+        : 'no-preference'
+  const prefersReducedTransparency = window.matchMedia('(prefers-reduced-transparency: reduce)')
+    .matches
+    ? 'reduce'
+    : 'no-preference'
+  const forcedColors = window.matchMedia('(forced-colors: active)').matches ? 'active' : null
+  const devicePixelRatio =
+    typeof window.devicePixelRatio === 'number'
+      ? Math.round(window.devicePixelRatio * 100) / 100
+      : null
+  const { pixelDepth, colorDepth } = window.screen
+  const touchSupport = 'ontouchstart' in window || window.navigator.maxTouchPoints > 0
+  const canvasID = await safe(() => getCanvasID(isDebug))
+  const webglID = await safe(() => getWebglID())
+  const webgpuID = await safe(() => getWebgpuID(isDebug))
+  const audioID = await safe(() => getAudioID(isDebug))
+  const aspectRatio =
+    window.screen.width && window.screen.height
+      ? (window.screen.width / window.screen.height).toFixed(4)
+      : null
+  const screenOrientation = await safe(
+    () => (window.screen.orientation && window.screen.orientation.type) || null
+  )
+  const networkConnection =
+    window.navigator.connection ||
+    window.navigator.mozConnection ||
+    window.navigator.webkitConnection
+  const connectionType = networkConnection ? networkConnection.type || null : null
+  const effectiveType =
+    networkConnection && networkConnection.effectiveType ? networkConnection.effectiveType : null
+  const saveData = networkConnection && networkConnection.saveData === true
+  const pdfViewerEnabled =
+    typeof window.navigator.pdfViewerEnabled === 'boolean'
+      ? window.navigator.pdfViewerEnabled
+      : null
+  const webdriver =
+    typeof window.navigator.webdriver === 'boolean' ? window.navigator.webdriver : null
+  const intlSupportedCalendars = await safe(() => {
+    if (typeof Intl.supportedValuesOf !== 'function') {
+      return null
+    }
+    return Intl.supportedValuesOf('calendar').join(',')
+  })
+  const permissionsState = await safe(async () => {
+    if (!window.navigator.permissions || typeof window.navigator.permissions.query !== 'function') {
+      return null
+    }
+    const permissionNames = ['geolocation', 'notifications']
+    const permissionStateMap = {}
+    for (const name of permissionNames) {
+      try {
+        const permissionResult = await window.navigator.permissions.query({ name })
+        permissionStateMap[name] = permissionResult.state
+      } catch {
+        permissionStateMap[name] = 'unsupported'
+      }
+    }
+    return stableStringify(permissionStateMap)
+  })
+  const data = {
+    vendor: window.navigator.vendor || null,
+    platform: window.navigator.platform || null,
+    userAgentHighEntropy: userAgentHighEntropy || null,
+    mediaCodecs: mediaCodecs || null,
+    fonts,
+    numberingSystem,
+    languages,
+    timezone,
+    timezoneOffset,
+    intlCalendar,
+    hourCycle,
+    reducedMotion,
+    colorScheme,
+    prefersContrast,
+    prefersReducedTransparency,
+    pdfViewerEnabled,
+    webdriver,
+    intlSupportedCalendars: intlSupportedCalendars || null,
+    permissionsState: permissionsState || null,
+    hardwareConcurrency: window.navigator.hardwareConcurrency || null,
+    deviceMemory: window.navigator.deviceMemory || null,
+    forcedColors,
+    devicePixelRatio,
+    pixelDepth,
+    colorDepth,
+    touchSupport,
+    screenOrientation: screenOrientation || null,
+    connectionType,
+    effectiveType,
+    saveData,
+    canvasID,
+    webglID,
+    webgpuID,
+    audioID
+  }
+  const mobileData = {
+    aspectRatio,
+    width: window.screen.width,
+    height: window.screen.height,
+    maxTouchPoints: window.navigator.maxTouchPoints
+  }
+  if (isMobile()) {
+    Object.assign(data, mobileData)
+  }
+  const payload = stableStringify(data)
+  const fingerprint = await sha256Hex(payload)
+  const elapsedMs = Math.round(performance.now() - startTime)
+  return { fingerprint, ...data, elapsedMs }
+}
+
+export default getBrowserFingerprint

--- a/src/index.js
+++ b/src/index.js
@@ -1,108 +1,108 @@
-const getAudioID = async isDebug => {
-  const OfflineCtx = window.OfflineAudioContext || window.webkitOfflineAudioContext
-  const context = new OfflineCtx(1, 6000, 44100)
-  const osc = context.createOscillator()
-  osc.type = 'sawtooth'
-  osc.frequency.value = 8800
-  const compressor = context.createDynamicsCompressor()
-  compressor.threshold.value = -48
-  compressor.knee.value = 30
-  compressor.ratio.value = 14
-  compressor.attack.value = 0
-  compressor.release.value = 0.3
-  const gain = context.createGain()
-  gain.gain.value = 0.4
-  osc.connect(compressor)
-  compressor.connect(gain)
-  gain.connect(context.destination)
-  osc.start(0)
-  const buffer = await context.startRendering()
-  const channel = buffer.getChannelData(0)
-  let hash = 0
-  let hash2 = 0
+const getAudioID = async (isDebug) => {
+  const OfflineCtx = window.OfflineAudioContext || window.webkitOfflineAudioContext;
+  const context = new OfflineCtx(1, 6000, 44100);
+  const osc = context.createOscillator();
+  osc.type = 'sawtooth';
+  osc.frequency.value = 8800;
+  const compressor = context.createDynamicsCompressor();
+  compressor.threshold.value = -48;
+  compressor.knee.value = 30;
+  compressor.ratio.value = 14;
+  compressor.attack.value = 0;
+  compressor.release.value = 0.3;
+  const gain = context.createGain();
+  gain.gain.value = 0.4;
+  osc.connect(compressor);
+  compressor.connect(gain);
+  gain.connect(context.destination);
+  osc.start(0);
+  const buffer = await context.startRendering();
+  const channel = buffer.getChannelData(0);
+  let hash = 0;
+  let hash2 = 0;
   for (let i = 3000; i < 5800; i += 2) {
-    const sampleValue = channel[i]
-    hash = (hash * 31 + Math.floor((sampleValue + 1) * 100000)) | 0
-    hash2 = Math.imul(hash2 ^ Math.floor(sampleValue * 98765), 0x85ebca77)
+    const sampleValue = channel[i];
+    hash = (hash * 31 + Math.floor((sampleValue + 1) * 100000)) | 0;
+    hash2 = Math.imul(hash2 ^ Math.floor(sampleValue * 98765), 0x85ebca77);
   }
-  const final = (hash >>> 0) ^ (hash2 >>> 0)
+  const final = (hash >>> 0) ^ (hash2 >>> 0);
   if (isDebug) {
-    const waveformCanvas = document.createElement('canvas')
-    waveformCanvas.width = 500
-    waveformCanvas.height = 120
-    waveformCanvas.style.border = '1px solid #444'
-    waveformCanvas.style.margin = '10px 0'
-    waveformCanvas.title = 'Audio buffer snippet (4500–5000 samples)'
-    const ctx = waveformCanvas.getContext('2d')
-    ctx.fillStyle = '#111'
-    ctx.fillRect(0, 0, waveformCanvas.width, waveformCanvas.height)
-    ctx.font = '14px monospace'
-    ctx.fillStyle = '#0f8'
-    ctx.textAlign = 'left'
-    ctx.fillText('AudioID', 10, 20)
-    ctx.strokeStyle = '#0f8'
-    ctx.lineWidth = 1.5
-    ctx.beginPath()
-    const waveform = Array.from(channel.slice(4500, 5000))
-    const step = waveformCanvas.width / waveform.length
+    const waveformCanvas = document.createElement('canvas');
+    waveformCanvas.width = 500;
+    waveformCanvas.height = 120;
+    waveformCanvas.style.border = '1px solid #444';
+    waveformCanvas.style.margin = '10px 0';
+    waveformCanvas.title = 'Audio buffer snippet (4500–5000 samples)';
+    const ctx = waveformCanvas.getContext('2d');
+    ctx.fillStyle = '#111';
+    ctx.fillRect(0, 0, waveformCanvas.width, waveformCanvas.height);
+    ctx.font = '14px monospace';
+    ctx.fillStyle = '#0f8';
+    ctx.textAlign = 'left';
+    ctx.fillText('AudioID', 10, 20);
+    ctx.strokeStyle = '#0f8';
+    ctx.lineWidth = 1.5;
+    ctx.beginPath();
+    const waveform = Array.from(channel.slice(4500, 5000));
+    const step = waveformCanvas.width / waveform.length;
     for (let i = 0; i < waveform.length; i++) {
-      const x = i * step
-      const y = ((waveform[i] + 1) / 2) * waveformCanvas.height
+      const x = i * step;
+      const y = ((waveform[i] + 1) / 2) * waveformCanvas.height;
       if (i === 0) {
-        ctx.moveTo(x, y)
+        ctx.moveTo(x, y);
       } else {
-        ctx.lineTo(x, y)
+        ctx.lineTo(x, y);
       }
     }
-    ctx.stroke()
-    document.body.appendChild(waveformCanvas)
+    ctx.stroke();
+    document.body.appendChild(waveformCanvas);
   }
-  return await sha256Hex(final.toString(16))
-}
+  return murmurHash3Hex(final.toString(16));
+};
 
-const getCanvasID = async isDebug => {
-  const canvas = document.createElement('canvas')
-  canvas.width = 280
-  canvas.height = 100
-  const ctx = canvas.getContext('2d')
-  const gradient = ctx.createLinearGradient(0, 0, 280, 100)
-  gradient.addColorStop(0, '#f60')
-  gradient.addColorStop(0.4, '#09f')
-  gradient.addColorStop(0.7, '#f09')
-  gradient.addColorStop(1, '#0f9')
-  ctx.fillStyle = gradient
-  ctx.fillRect(0, 0, 280, 100)
-  ctx.font = '18px "Arial","Helvetica","DejaVu Sans",sans-serif'
-  ctx.fillStyle = '#000'
-  ctx.textBaseline = 'alphabetic'
-  ctx.fillText('Fingerprint ¼½¾™©®∆π∑€¶§', 12, 45)
-  ctx.font = 'bold 22px "Georgia","Times New Roman",serif'
-  ctx.fillStyle = '#222'
-  ctx.fillText('🦊🐱🚀 2026', 12, 78)
-  ctx.globalAlpha = 0.7
-  ctx.fillStyle = 'rgba(255, 80, 0, 0.35)'
-  ctx.fillRect(180, 20, 80, 60)
-  ctx.beginPath()
-  ctx.arc(220, 50, 32, 0, Math.PI * 2)
-  ctx.strokeStyle = '#fff'
-  ctx.lineWidth = 4
-  ctx.stroke()
-  ctx.beginPath()
-  ctx.moveTo(30, 85)
-  ctx.quadraticCurveTo(140, 20, 240, 85)
-  ctx.strokeStyle = '#00f'
-  ctx.lineWidth = 3
-  ctx.stroke()
+const getCanvasID = async (isDebug) => {
+  const canvas = document.createElement('canvas');
+  canvas.width = 280;
+  canvas.height = 100;
+  const ctx = canvas.getContext('2d');
+  const gradient = ctx.createLinearGradient(0, 0, 280, 100);
+  gradient.addColorStop(0, '#f60');
+  gradient.addColorStop(0.4, '#09f');
+  gradient.addColorStop(0.7, '#f09');
+  gradient.addColorStop(1, '#0f9');
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, 280, 100);
+  ctx.font = '18px "Arial","Helvetica","DejaVu Sans",sans-serif';
+  ctx.fillStyle = '#000';
+  ctx.textBaseline = 'alphabetic';
+  ctx.fillText('Fingerprint ¼½¾™©®∆π∑€¶§', 12, 45);
+  ctx.font = 'bold 22px "Georgia","Times New Roman",serif';
+  ctx.fillStyle = '#222';
+  ctx.fillText('🦊🐱🚀 2026', 12, 78);
+  ctx.globalAlpha = 0.7;
+  ctx.fillStyle = 'rgba(255, 80, 0, 0.35)';
+  ctx.fillRect(180, 20, 80, 60);
+  ctx.beginPath();
+  ctx.arc(220, 50, 32, 0, Math.PI * 2);
+  ctx.strokeStyle = '#fff';
+  ctx.lineWidth = 4;
+  ctx.stroke();
+  ctx.beginPath();
+  ctx.moveTo(30, 85);
+  ctx.quadraticCurveTo(140, 20, 240, 85);
+  ctx.strokeStyle = '#00f';
+  ctx.lineWidth = 3;
+  ctx.stroke();
   if (isDebug) {
-    canvas.style.border = '1px solid #444'
-    document.body.appendChild(canvas)
+    canvas.style.border = '1px solid #444';
+    document.body.appendChild(canvas);
   }
-  const dataUrl = canvas.toDataURL('image/png')
-  return await sha256Hex(dataUrl)
-}
+  const dataUrl = canvas.toDataURL('image/png');
+  return murmurHash3Hex(dataUrl);
+};
 
 const getFonts = () => {
-  const baseFonts = ['monospace', 'serif', 'sans-serif']
+  const baseFonts = ['monospace', 'serif', 'sans-serif'];
   const testFonts = [
     'Arial',
     'Helvetica',
@@ -118,242 +118,226 @@ const getFonts = () => {
     'Noto Sans',
     'system-ui',
     '-apple-system',
-    'BlinkMacSystemFont'
-  ]
-  const span = document.createElement('span')
-  span.style.fontSize = '72px'
-  span.style.position = 'absolute'
-  span.style.visibility = 'hidden'
-  span.style.whiteSpace = 'nowrap'
-  span.textContent = 'mmmmmmmmmwwwwwww'
-  document.body.appendChild(span)
-  const defaults = {}
+    'BlinkMacSystemFont',
+  ];
+  const span = document.createElement('span');
+  span.style.fontSize = '72px';
+  span.style.position = 'absolute';
+  span.style.visibility = 'hidden';
+  span.style.whiteSpace = 'nowrap';
+  span.textContent = 'mmmmmmmmmwwwwwww';
+  document.body.appendChild(span);
+  const defaults = {};
   for (const base of baseFonts) {
-    span.style.fontFamily = base
-    defaults[base] = span.offsetWidth
+    span.style.fontFamily = base;
+    defaults[base] = span.offsetWidth;
   }
-  const detected = []
+  const detected = [];
   for (const font of testFonts) {
-    let found = false
+    let found = false;
     for (const base of baseFonts) {
-      span.style.fontFamily = `"${font}", ${base}`
+      span.style.fontFamily = `"${font}", ${base}`;
       if (span.offsetWidth !== defaults[base]) {
-        detected.push(font)
-        found = true
-        break
+        detected.push(font);
+        found = true;
+        break;
       }
     }
     if (!found) {
-      span.style.fontFamily = `"${font}"`
+      span.style.fontFamily = `"${font}"`;
       if (span.offsetWidth !== defaults.monospace && span.offsetWidth !== defaults.serif) {
-        detected.push(font)
+        detected.push(font);
       }
     }
   }
-  document.body.removeChild(span)
-  return detected.length ? detected.sort().join(',') : null
-}
+  document.body.removeChild(span);
+  return detected.length ? detected.sort().join(',') : null;
+};
 
 const getMediaCodecs = () => {
-  const video = document.createElement('video')
-  const mimeList = [
-    'video/webm',
-    'video/mp4',
-    'video/ogg',
-    'audio/mp4',
-    'audio/webm',
-    'audio/ogg',
-    'audio/mpeg'
-  ]
-  const codecSupportMap = {}
+  const video = document.createElement('video');
+  const mimeList = ['video/webm', 'video/mp4', 'video/ogg', 'audio/mp4', 'audio/webm', 'audio/ogg', 'audio/mpeg'];
+  const codecSupportMap = {};
   for (const mime of mimeList) {
-    const playbackSupport = video.canPlayType(mime)
-    codecSupportMap[mime] = playbackSupport === '' ? 'no' : playbackSupport
+    const playbackSupport = video.canPlayType(mime);
+    codecSupportMap[mime] = playbackSupport === '' ? 'no' : playbackSupport;
   }
-  return stableStringify(codecSupportMap)
-}
+  return stableStringify(codecSupportMap);
+};
 
 const getWebglID = async () => {
-  const canvas = document.createElement('canvas')
-  const gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl')
-  const debugInfo = gl.getExtension('WEBGL_debug_renderer_info')
-  const vendor = debugInfo
-    ? gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL)
-    : gl.getParameter(gl.VENDOR)
-  const renderer = debugInfo
-    ? gl.getParameter(debugInfo.UNMASKED_RENDERER_WEBGL)
-    : gl.getParameter(gl.RENDERER)
-  const webglInfo = { vendor, renderer }
-  return await sha256Hex(stableStringify(webglInfo))
-}
+  const canvas = document.createElement('canvas');
+  const gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl');
+  const debugInfo = gl.getExtension('WEBGL_debug_renderer_info');
+  const vendor = debugInfo ? gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL) : gl.getParameter(gl.VENDOR);
+  const renderer = debugInfo ? gl.getParameter(debugInfo.UNMASKED_RENDERER_WEBGL) : gl.getParameter(gl.RENDERER);
+  const webglInfo = { vendor, renderer };
+  return murmurHash3Hex(stableStringify(webglInfo));
+};
 
-const getWebgpuID = async isDebug => {
-  const adapter = await navigator.gpu.requestAdapter({ powerPreference: 'high-performance' })
-  const vendor = adapter.info?.vendor ?? ''
-  const architecture = adapter.info?.architecture ?? ''
-  const description = adapter.info?.description ?? ''
-  const features = Array.from(adapter.features).sort()
-  const limits = Array.from(adapter.limits).sort()
-  const webgpuInfo = { vendor, architecture, description, features, limits }
+const getWebgpuID = async (isDebug) => {
+  const adapter = await navigator.gpu.requestAdapter({ powerPreference: 'high-performance' });
+  const vendor = adapter.info?.vendor ?? '';
+  const architecture = adapter.info?.architecture ?? '';
+  const description = adapter.info?.description ?? '';
+  const features = Array.from(adapter.features).sort();
+  const limits = Array.from(adapter.limits).sort();
+  const webgpuInfo = { vendor, architecture, description, features, limits };
   if (isDebug) {
-    const debugDiv = document.createElement('pre')
-    debugDiv.style.margin = '10px 0'
-    debugDiv.style.padding = '10px'
-    debugDiv.style.border = '1px solid #444'
-    debugDiv.style.background = '#111'
-    debugDiv.style.color = '#0f8'
-    debugDiv.style.fontFamily = 'monospace'
-    debugDiv.textContent = `WebGPU:\n${JSON.stringify(webgpuInfo, null, 2)}`
-    document.body.appendChild(debugDiv)
+    const debugDiv = document.createElement('pre');
+    debugDiv.style.margin = '10px 0';
+    debugDiv.style.padding = '10px';
+    debugDiv.style.border = '1px solid #444';
+    debugDiv.style.background = '#111';
+    debugDiv.style.color = '#0f8';
+    debugDiv.style.fontFamily = 'monospace';
+    debugDiv.textContent = `WebGPU:\n${JSON.stringify(webgpuInfo, null, 2)}`;
+    document.body.appendChild(debugDiv);
   }
-  return await sha256Hex(stableStringify(webgpuInfo))
-}
+  return murmurHash3Hex(stableStringify(webgpuInfo));
+};
 
 const isMobile = () =>
   navigator.userAgentData?.mobile === true ||
   /Mobi|Android|iPhone|iPad|iPod|webOS|BlackBerry|Windows Phone/i.test(navigator.userAgent) ||
-  (navigator.maxTouchPoints > 0 && matchMedia('(pointer:coarse)').matches && innerWidth <= 1024)
+  (navigator.maxTouchPoints > 0 && matchMedia('(pointer:coarse)').matches && innerWidth <= 1024);
 
-const safe = async asyncFn => {
+const safe = async (asyncFn) => {
   try {
-    return await asyncFn()
+    return await asyncFn();
   } catch {
-    return null
+    return null;
   }
-}
+};
 
-const sha256Hex = async inputString => {
-  const hashBuffer = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(inputString))
-  return Array.from(new Uint8Array(hashBuffer))
-    .map(byte => byte.toString(16).padStart(2, '0'))
-    .join('')
-}
+const murmurHash3Hex = (inputString, seed = 1) => {
+  const data = new TextEncoder().encode(inputString);
+  const c1 = 0xcc9e2d51;
+  const c2 = 0x1b873593;
+  let h1 = seed >>> 0;
 
-const stableStringify = value => {
+  const blockCount = Math.floor(data.length / 4);
+  const dataView = new DataView(data.buffer, data.byteOffset, data.byteLength);
+  for (let i = 0; i < blockCount; i++) {
+    let k1 = dataView.getUint32(i * 4, true);
+    k1 = Math.imul(k1, c1);
+    k1 = (k1 << 15) | (k1 >>> 17);
+    k1 = Math.imul(k1, c2);
+    h1 ^= k1;
+    h1 = (h1 << 13) | (h1 >>> 19);
+    h1 = (Math.imul(h1, 5) + 0xe6546b64) >>> 0;
+  }
+
+  let k1 = 0;
+  const tailIndex = blockCount * 4;
+  const remainder = data.length & 3;
+  if (remainder === 3) {
+    k1 ^= data[tailIndex + 2] << 16;
+  }
+  if (remainder >= 2) {
+    k1 ^= data[tailIndex + 1] << 8;
+  }
+  if (remainder >= 1) {
+    k1 ^= data[tailIndex];
+    k1 = Math.imul(k1, c1);
+    k1 = (k1 << 15) | (k1 >>> 17);
+    k1 = Math.imul(k1, c2);
+    h1 ^= k1;
+  }
+
+  h1 ^= data.length;
+  h1 ^= h1 >>> 16;
+  h1 = Math.imul(h1, 0x85ebca6b) >>> 0;
+  h1 ^= h1 >>> 13;
+  h1 = Math.imul(h1, 0xc2b2ae35) >>> 0;
+  h1 ^= h1 >>> 16;
+  return h1.toString(16).padStart(8, '0');
+};
+
+const stableStringify = (value) => {
   if (value === null || typeof value !== 'object') {
-    return JSON.stringify(value)
+    return JSON.stringify(value);
   }
   if (Array.isArray(value)) {
-    return `[${value.map(stableStringify).join(',')}]`
+    return `[${value.map(stableStringify).join(',')}]`;
   }
-  const keys = Object.keys(value).sort()
-  const parts = []
+  const keys = Object.keys(value).sort();
+  const parts = [];
   for (const key of keys) {
-    const item = value[key]
+    const item = value[key];
     if (item !== undefined) {
-      parts.push(`${stableStringify(key)}:${stableStringify(item)}`)
+      parts.push(`${stableStringify(key)}:${stableStringify(item)}`);
     }
   }
-  return `{${parts.join(',')}}`
-}
+  return `{${parts.join(',')}}`;
+};
 
 const getBrowserFingerprint = async ({ debug: isDebug = false } = {}) => {
-  const startTime = performance.now()
+  const startTime = performance.now();
   const userAgentHighEntropy = await safe(async () => {
-    if (
-      !window.navigator.userAgentData ||
-      typeof window.navigator.userAgentData.getHighEntropyValues !== 'function'
-    ) {
-      return null
+    if (!window.navigator.userAgentData || typeof window.navigator.userAgentData.getHighEntropyValues !== 'function') {
+      return null;
     }
-    const highEntropyValues = await window.navigator.userAgentData.getHighEntropyValues([
-      'architecture',
-      'bitness',
-      'platformVersion',
-      'model',
-      'fullVersionList'
-    ])
-    return stableStringify(highEntropyValues)
-  })
-  const mediaCodecs = await safe(() => getMediaCodecs())
-  const fonts = await safe(() => getFonts())
-  const numberingSystem = await safe(
-    () =>
-      new Intl.NumberFormat(window.navigator.languages?.[0] || 'en').resolvedOptions()
-        .numberingSystem
-  )
-  const languages = window.navigator.languages
-    ? Array.from(window.navigator.languages).join(',')
-    : window.navigator.language || null
-  const intlResolved = Intl.DateTimeFormat().resolvedOptions()
-  const timezone = intlResolved.timeZone
-  const timezoneOffset = new Date().getTimezoneOffset()
-  const intlCalendar = intlResolved.calendar || null
-  const hourCycle =
-    intlResolved.hour12 !== undefined
-      ? intlResolved.hour12
-        ? 'h12'
-        : 'h23'
-      : intlResolved.hourCycle || null
-  const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches
-    ? 'reduce'
-    : 'no-preference'
-  const colorScheme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+    const highEntropyValues = await window.navigator.userAgentData.getHighEntropyValues(['architecture', 'bitness', 'platformVersion', 'model', 'fullVersionList']);
+    return stableStringify(highEntropyValues);
+  });
+  const mediaCodecs = await safe(() => getMediaCodecs());
+  const fonts = await safe(() => getFonts());
+  const numberingSystem = await safe(() => new Intl.NumberFormat(window.navigator.languages?.[0] || 'en').resolvedOptions().numberingSystem);
+  const languages = window.navigator.languages ? Array.from(window.navigator.languages).join(',') : window.navigator.language || null;
+  const intlResolved = Intl.DateTimeFormat().resolvedOptions();
+  const timezone = intlResolved.timeZone;
+  const timezoneOffset = new Date().getTimezoneOffset();
+  const intlCalendar = intlResolved.calendar || null;
+  const hourCycle = intlResolved.hour12 !== undefined ? (intlResolved.hour12 ? 'h12' : 'h23') : intlResolved.hourCycle || null;
+  const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches ? 'reduce' : 'no-preference';
+  const colorScheme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
   const prefersContrast = window.matchMedia('(prefers-contrast: more)').matches
     ? 'more'
     : window.matchMedia('(prefers-contrast: less)').matches
       ? 'less'
       : window.matchMedia('(prefers-contrast: custom)').matches
         ? 'custom'
-        : 'no-preference'
-  const prefersReducedTransparency = window.matchMedia('(prefers-reduced-transparency: reduce)')
-    .matches
-    ? 'reduce'
-    : 'no-preference'
-  const forcedColors = window.matchMedia('(forced-colors: active)').matches ? 'active' : null
-  const devicePixelRatio =
-    typeof window.devicePixelRatio === 'number'
-      ? Math.round(window.devicePixelRatio * 100) / 100
-      : null
-  const { pixelDepth, colorDepth } = window.screen
-  const touchSupport = 'ontouchstart' in window || window.navigator.maxTouchPoints > 0
-  const canvasID = await safe(() => getCanvasID(isDebug))
-  const webglID = await safe(() => getWebglID())
-  const webgpuID = await safe(() => getWebgpuID(isDebug))
-  const audioID = await safe(() => getAudioID(isDebug))
-  const aspectRatio =
-    window.screen.width && window.screen.height
-      ? (window.screen.width / window.screen.height).toFixed(4)
-      : null
-  const screenOrientation = await safe(
-    () => (window.screen.orientation && window.screen.orientation.type) || null
-  )
-  const networkConnection =
-    window.navigator.connection ||
-    window.navigator.mozConnection ||
-    window.navigator.webkitConnection
-  const connectionType = networkConnection ? networkConnection.type || null : null
-  const effectiveType =
-    networkConnection && networkConnection.effectiveType ? networkConnection.effectiveType : null
-  const saveData = networkConnection && networkConnection.saveData === true
-  const pdfViewerEnabled =
-    typeof window.navigator.pdfViewerEnabled === 'boolean'
-      ? window.navigator.pdfViewerEnabled
-      : null
-  const webdriver =
-    typeof window.navigator.webdriver === 'boolean' ? window.navigator.webdriver : null
+        : 'no-preference';
+  const prefersReducedTransparency = window.matchMedia('(prefers-reduced-transparency: reduce)').matches ? 'reduce' : 'no-preference';
+  const forcedColors = window.matchMedia('(forced-colors: active)').matches ? 'active' : null;
+  const devicePixelRatio = typeof window.devicePixelRatio === 'number' ? Math.round(window.devicePixelRatio * 100) / 100 : null;
+  const { pixelDepth, colorDepth } = window.screen;
+  const touchSupport = 'ontouchstart' in window || window.navigator.maxTouchPoints > 0;
+  const canvasID = await safe(() => getCanvasID(isDebug));
+  const webglID = await safe(() => getWebglID());
+  const webgpuID = await safe(() => getWebgpuID(isDebug));
+  const audioID = await safe(() => getAudioID(isDebug));
+  const aspectRatio = window.screen.width && window.screen.height ? (window.screen.width / window.screen.height).toFixed(4) : null;
+  const screenOrientation = await safe(() => window.screen.orientation?.type || null);
+  const networkConnection = window.navigator.connection || window.navigator.mozConnection || window.navigator.webkitConnection;
+  const connectionType = networkConnection ? networkConnection.type || null : null;
+  const effectiveType = networkConnection?.effectiveType || null;
+  const saveData = networkConnection?.saveData === true;
+  const pdfViewerEnabled = typeof window.navigator.pdfViewerEnabled === 'boolean' ? window.navigator.pdfViewerEnabled : null;
+  const webdriver = typeof window.navigator.webdriver === 'boolean' ? window.navigator.webdriver : null;
   const intlSupportedCalendars = await safe(() => {
     if (typeof Intl.supportedValuesOf !== 'function') {
-      return null
+      return null;
     }
-    return Intl.supportedValuesOf('calendar').join(',')
-  })
+    return Intl.supportedValuesOf('calendar').join(',');
+  });
   const permissionsState = await safe(async () => {
     if (!window.navigator.permissions || typeof window.navigator.permissions.query !== 'function') {
-      return null
+      return null;
     }
-    const permissionNames = ['geolocation', 'notifications']
-    const permissionStateMap = {}
+    const permissionNames = ['geolocation', 'notifications'];
+    const permissionStateMap = {};
     for (const name of permissionNames) {
       try {
-        const permissionResult = await window.navigator.permissions.query({ name })
-        permissionStateMap[name] = permissionResult.state
+        const permissionResult = await window.navigator.permissions.query({ name });
+        permissionStateMap[name] = permissionResult.state;
       } catch {
-        permissionStateMap[name] = 'unsupported'
+        permissionStateMap[name] = 'unsupported';
       }
     }
-    return stableStringify(permissionStateMap)
-  })
+    return stableStringify(permissionStateMap);
+  });
   const data = {
     vendor: window.navigator.vendor || null,
     platform: window.navigator.platform || null,
@@ -388,21 +372,25 @@ const getBrowserFingerprint = async ({ debug: isDebug = false } = {}) => {
     canvasID,
     webglID,
     webgpuID,
-    audioID
-  }
+    audioID,
+  };
   const mobileData = {
     aspectRatio,
     width: window.screen.width,
     height: window.screen.height,
-    maxTouchPoints: window.navigator.maxTouchPoints
-  }
+    maxTouchPoints: window.navigator.maxTouchPoints,
+  };
   if (isMobile()) {
-    Object.assign(data, mobileData)
+    Object.assign(data, mobileData);
   }
-  const payload = stableStringify(data)
-  const fingerprint = await sha256Hex(payload)
-  const elapsedMs = Math.round(performance.now() - startTime)
-  return { fingerprint, ...data, elapsedMs }
+  const payload = stableStringify(data);
+  const fingerprint = murmurHash3Hex(payload);
+  const elapsedMs = Math.round(performance.now() - startTime);
+  return { fingerprint, ...data, elapsedMs };
+};
+
+if (typeof window !== 'undefined') {
+  window.getBrowserFingerprint = getBrowserFingerprint;
 }
 
-export default getBrowserFingerprint
+export default getBrowserFingerprint;


### PR DESCRIPTION

## Summary

This PR updates the fingerprint pipeline to use **SHA-256** (64-char hex) instead of MurmurHash3, adds more signals, returns execution time and all signals, and improves the README with usage, CDN examples, and references.

## Changes

### Fingerprint & payload
- **Hash:** MurmurHash3 replaced with `crypto.subtle.digest('SHA-256', …)`; fingerprint is now a 64-character hex string.
- **Return value:** In addition to `fingerprint`, the function now returns `elapsedMs` (execution time in ms) and spreads all collected signals on the result object.
- **New/expanded signals:**
  - **UA / platform:** `userAgentHighEntropy` (UA Client Hints: architecture, bitness, platformVersion, model, fullVersionList).
  - **Locale / Intl:** `intlCalendar`, `hourCycle`, `intlSupportedCalendars`.
  - **Preferences:** `prefersContrast`, `prefersReducedTransparency`.
  - **Screen:** `devicePixelRatio`, `screenOrientation`.
  - **Network:** `connectionType`, `effectiveType`, `saveData` (when available).
  - **Media:** `mediaCodecs` (canPlayType for common video/audio MIME types).
  - **Other:** `pdfViewerEnabled`, `webdriver`, `permissionsState` (geolocation, notifications).
- Unavailable or failed signals are set to `null`; the function does not throw.

### README
- **Return value:** Documents `fingerprint`, `elapsedMs`, and spread of signals.
- **Collected signals:** List of all signals by category.
- **Assumptions:** Shortened and aligned with current behavior.
- **Usage:** Step-by-step example with comments; optional `debug` usage.
- **CDN:** ESM examples via jsDelivr (latest and version-pinned).
- **Development:** Install, test, and serve instructions; note about secure context for `crypto.subtle`.
- **References:** MDN and W3C links (fingerprinting, Client Hints, Navigator, Screen, NetworkInformation, Intl, Permissions, SubtleCrypto, etc.) sorted A–Z.

## Compatibility

- **Breaking:** Fingerprint format changes from 8-char hex (MurmurHash3) to 64-char hex (SHA-256). Callers that store or compare the old format will need to migrate.
- **API:** Same function signature `getBrowserFingerprint({ debug }?)`; only the shape and content of the returned object are extended.
- **Environment:** Still requires a secure context (HTTPS or localhost) for `crypto.subtle`.
